### PR TITLE
WEB-4202 - 22806 - Ao emitir boleto via banco Caixa Econômica Federal é retornado erro:  O valor XXXXXXXXXX possui mais de 6 dígitos!

### DIFF
--- a/src/OpenBoleto/Banco/Caixa.php
+++ b/src/OpenBoleto/Banco/Caixa.php
@@ -89,7 +89,7 @@ class Caixa extends BoletoAbstract
      */
     public function setConta($conta)
     {
-        $this->conta = self::zeroFill($conta, 6);
+        $this->conta = self::zeroFill($conta, 12);
         return $this;
     }
 
@@ -108,7 +108,7 @@ class Caixa extends BoletoAbstract
         // se futuramente o projeto permitir a geração de lotes para inclusão, o tipo registrado pode ser útil
         // 1 => registrada, 2 => sem registro. O número 4 indica que é o beneficiário que está gerando o boleto
         $carteira = $this->getCarteira();
-        if ($carteira == 'SR'){
+        if ($carteira == 'SR') {
             $numero = '24';
         } else {
             $numero = '14';
@@ -116,7 +116,7 @@ class Caixa extends BoletoAbstract
 
         // As 15 próximas posições no nosso número são a critério do beneficiário, utilizando o sequencial
         // Depois, calcula-se o código verificador por módulo 11
-        $modulo = self::modulo11($numero.self::zeroFill($sequencial, 15));
+        $modulo = self::modulo11($numero . self::zeroFill($sequencial, 15));
         $numero .= self::zeroFill($sequencial, 15) . '-' . $modulo['digito'];
 
         return $numero;
@@ -155,7 +155,7 @@ class Caixa extends BoletoAbstract
 
         // Sequencia 1 (posições 3-5 NN) + Constante 1 (1 => registrada, 2 => sem registro)
         $carteira = $this->getCarteira();
-        if ($carteira == 'SR'){
+        if ($carteira == 'SR') {
             $constante = '2';
         } else {
             $constante = '1';
@@ -172,7 +172,6 @@ class Caixa extends BoletoAbstract
         $modulo = self::modulo11($campoLivre);
         $campoLivre .= $modulo['digito'];
 
-       return $campoLivre;
+        return $campoLivre;
     }
-
 }


### PR DESCRIPTION
[//]: # (jira: "{"jiraIssueId":"20274","updatedAt":"2025-03-13T08:09:57.095-0300"}")

> [!NOTE]
> Card: <https://zucchettibr.atlassian.net/browse/WEB-4202> - 22806 - Ao emitir boleto via banco Caixa Econômica Federal é retornado erro:  O valor XXXXXXXXXX possui mais de 6 dígitos!
> Autor: @filipe-golfe

## Descrição
<p>*<b>Comportamento Atual/Problema</b>*</p>

<p>Ao emitir boleto via banco Caixa Econômica Federal é retornado erro:</p>

<p>O valor 000578279893 possui mais de 6 dígitos!</p>

<p><a href="https://prnt.sc/OjtaD957sy47" class="external-link" rel="nofollow noreferrer">https://prnt.sc/OjtaD957sy47</a></p>

<p>Consultando o manual, podemos ver que o banco aceita até 12 dígitos sem DV. <a href="https://prnt.sc/PsrP06yOGXSL" class="external-link" rel="nofollow noreferrer">https://prnt.sc/PsrP06yOGXSL</a></p>

<p>*<b>Comportamento esperado/Sugestão de Solução</b>*</p>

<p>Ajuste na emissão de boletos quando o Número da conta possuir mais de 6 dígitos.</p>

<p>*<b>Passos para reproduzir o comportamento</b>*</p>

<p>Acesse o link: <a href="https://zweb.com.br/#/sign-in" class="external-link" rel="nofollow noreferrer">https://zweb.com.br/#/sign-in</a><br/>
Efetue login na conta em anexo.<br/>
Acesse o menu Financeiro &gt; Receitas.<br/>
Efetue geração de boleto via banco Caixa Econômica Federal do documento 1-01.<br/>
Verifique que retorna erro. <a href="https://prnt.sc/OjtaD957sy47" class="external-link" rel="nofollow noreferrer">https://prnt.sc/OjtaD957sy47</a></p>

<p>*<b>Informações Adicionais / Processos já efetuados no cliente</b>*</p>

<p>Manual Banco: <a href="https://www.caixa.gov.br/Downloads/cobranca-caixa/Manual_de_Leiaute_de_Arquivo_Eletronico_CNAB_400.pdf" class="external-link" rel="nofollow noreferrer">https://www.caixa.gov.br/Downloads/cobranca-caixa/Manual_de_Leiaute_de_Arquivo_Eletronico_CNAB_400.pdf</a></p>

<p>*<b>Anexe os arquivos necessários (XML, prints, etc), se tiver</b>*</p>

<p>*<b>Link da BDC e serial para acesso</b>*</p>

## Nota técnica do desenvolvedor
<p>Ajustei função que jogava a exception aumentando o tamanho de 6 para 12 (pois não considera o DV).</p>

<p>Testar:</p>

<p>Geração de boletos e remessas do CEF com vários dígitos na conta (remessa não mexi, mas é bom dar uma revisada também), segue validador: <a href="https://validadordearquivos.caixa.gov.br/sivcb/pages/validacao/validador.xhtml" class="external-link" rel="nofollow noreferrer">https://validadordearquivos.caixa.gov.br/sivcb/pages/validacao/validador.xhtml</a></p>

<p>Para testar precisará ajustar o arquivo o método setConta no arquivo Backend/vendor/zucchetti-pos/openboleto/src/OpenBoleto/Banco/Caixa.php, trocar a quantidade de dígitos que manda na função de 6 para 12.</p>