### PR TITLE
WEB-4911 23896 - Boleto Sicoob no campo pagador apresenta sempre CNPJ mesmo que seja pessoa física #1

### DIFF
--- a/resources/views/sicoob.phtml
+++ b/resources/views/sicoob.phtml
@@ -1,3 +1,28 @@
+<?php
+function formatarCpfCnpj(string $documento): string
+{
+    $doc = preg_replace('/\D/', '', $documento);
+
+    if (strlen($doc) === 11) {
+        return preg_replace(
+            '/(\d{3})(\d{3})(\d{3})(\d{2})/',
+            '$1.$2.$3-$4',
+            $doc
+        );
+    }
+
+    if (strlen($doc) === 14) {
+        return preg_replace(
+            '/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/',
+            '$1.$2.$3/$4-$5',
+            $doc
+        );
+    }
+
+    return $documento;
+}
+?>
+
 <!DOCTYPE html>
 <!--
  * OpenBoleto - Geração de boletos bancários em PHP
@@ -107,9 +132,20 @@
                     <?php
                     echo preg_replace('/\s*\(.*?\)\s*/', '', $sacado);
 
-                    if (!empty($sacado_documento)) {
-                        $cnpj = preg_replace('/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/', '$1.$2.$3/$4-$5', $sacado_documento);
-                        echo ' - CNPJ: ' . $cnpj;
+                    if (! empty($sacado_documento)) {
+                        $apenasDigitos = preg_replace('/\D/', '', $sacado_documento);
+                        $len = strlen($apenasDigitos);
+
+                        $labels = [
+                            11 => 'CPF',
+                            14 => 'CNPJ',
+                        ];
+
+                        $label = isset($labels[$len])
+                            ? $labels[$len]
+                            : 'Documento';
+
+                        echo ' – ' . $label . ': ' . formatarCpfCnpj($sacado_documento);
                     }
                     ?>
                 </div>


### PR DESCRIPTION
Com a criação da sugestão de número 23289
Surgiu a situação de que no campo do pagador, está apresentado a opção CNPJ sempre, mesmo que o pagador seja CPF
https://prnt.sc/QQgSsftcrec8

Comportamento esperado/Sugestão de Solução

Ajustar para que conforme o tipo de pagador, PJ ou PF saia os dados corretos CNPJ ou CPF

Passos para reproduzir o comportamento

Acesso modulo de receitas, e imprima o boleto do documento 0101-01
https://prnt.sc/E9boS7g8SPA_

Informações Adicionais / Processos já efetuados no cliente

Em conversa com o Martin solicitou que fosse criado o incidente.

Anexe os arquivos necessários (XML, prints, etc), se tiver